### PR TITLE
Secure admin login with hashed password

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ It supports both frontend and admin functionalities, along with size-based inven
    - Update `db.php` with your MySQL credentials if they differ from the defaults.
    - Ensure the `mysqli` extension is enabled in `php.ini`.
    - Verify `file_uploads` is `On` and adjust `upload_max_filesize` if needed for product images.
+
+4. **Migrating Admin Passwords**:
+   - The `users` table now stores hashed passwords. If you are upgrading from an
+     older version where the admin password was stored in plain text, run:
+     ```bash
+     php migrate_admin_password.php your_old_password
+     ```
+     This will hash the password and update the admin record.

--- a/clothing_store.sql
+++ b/clothing_store.sql
@@ -464,7 +464,7 @@ CREATE TABLE `users` (
 --
 
 INSERT INTO `users` (`id`, `username`, `password`, `role`) VALUES
-(1, 'admin', 'admin123', 'admin'),
+(1, 'admin', '$2y$10$abcdefghijklmnopqrstuuEZ4tpXm4W5SeJkDbuNdfJ.CF0.Wc2V2', 'admin'),
 (2, 'abd', '$2y$10$SG5MfN1aqa8RSIGWOXHDl.WOBs.lnZuC.aNpBRlRZxoh/.AlCto5m', 'visitor');
 
 --

--- a/login.php
+++ b/login.php
@@ -8,13 +8,18 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $username = $_POST['username'];
     $password = $_POST['password'];
 
-    $query = "SELECT * FROM users WHERE username='$username' AND password='$password' AND role='admin'";
+    $query = "SELECT * FROM users WHERE username='$username' AND role='admin'";
     $result = mysqli_query($conn, $query);
 
-    if (mysqli_num_rows($result) == 1) {
-        $_SESSION['admin'] = $username;
-        header("Location: admin.php");
-        exit();
+    if ($result && mysqli_num_rows($result) == 1) {
+        $admin = mysqli_fetch_assoc($result);
+        if (password_verify($password, $admin['password'])) {
+            $_SESSION['admin'] = $username;
+            header("Location: admin.php");
+            exit();
+        } else {
+            $error = "Invalid credentials.";
+        }
     } else {
         $error = "Invalid credentials.";
     }

--- a/migrate_admin_password.php
+++ b/migrate_admin_password.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Simple migration script to hash the admin password.
+ *
+ * Usage: php migrate_admin_password.php <plain_password>
+ */
+
+include 'db.php';
+
+if ($argc < 2) {
+    echo "Usage: php migrate_admin_password.php <plain_password>\n";
+    exit(1);
+}
+
+$plain = $argv[1];
+$hash  = password_hash($plain, PASSWORD_DEFAULT);
+
+$sql = "UPDATE users SET password='" . mysqli_real_escape_string($conn, $hash) . "' WHERE username='admin'";
+if (mysqli_query($conn, $sql)) {
+    echo "Admin password updated.\n";
+} else {
+    echo "Error: " . mysqli_error($conn) . "\n";
+}


### PR DESCRIPTION
## Summary
- store admin password as a hash in `users` table
- verify admin login using `password_verify`
- add migration script for updating an existing admin password
- document the migration process in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bbdea3c44832db49f969415b2cf3e