### PR TITLE
Implement CSRF tokens across forms

### DIFF
--- a/add.php
+++ b/add.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 include 'db.php';
+include 'csrf.php';
 
 // حماية الأدمن
 if (!isset($_SESSION['admin'])) {
@@ -16,6 +17,9 @@ $category_result = mysqli_query($conn, "SELECT * FROM categories");
 $sizes = ['XS', 'S', 'M', 'L', 'XL', 'XXL'];
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    if (!verify_csrf_token($_POST['token'] ?? '')) {
+        die('Invalid CSRF token');
+    }
     $name = $_POST['name'];
     $price = $_POST['price'];
     $description = $_POST['description'];
@@ -65,6 +69,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
     <div class="card p-4 shadow mx-auto" style="max-width: 600px;">
         <form action="add.php" method="POST" enctype="multipart/form-data">
+            <input type="hidden" name="token" value="<?php echo get_csrf_token(); ?>">
             <div class="mb-3">
                 <label class="form-label">Product Name:</label>
                 <input type="text" name="name" class="form-control" required>

--- a/add_to_cart.php
+++ b/add_to_cart.php
@@ -1,8 +1,14 @@
 <?php
 session_start();
 include 'db.php';
+include 'csrf.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!verify_csrf_token($_POST['token'] ?? '')) {
+        $_SESSION['message'] = 'Invalid CSRF token';
+        header('Location: cart.php');
+        exit();
+    }
     $id = (int) $_POST['product_id'];
     $size = mysqli_real_escape_string($conn, $_POST['size']);
     $qty = max(1, (int) $_POST['quantity']); // والـ quantity رح توصل كـ hidden = 1

--- a/cart.php
+++ b/cart.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 include 'db.php';
+include 'csrf.php';
 
 $cart = $_SESSION['cart'] ?? [];
 $total = 0;
@@ -85,6 +86,7 @@ $total = 0;
 
 <!-- ✅ JavaScript -->
 <script>
+const csrfToken = '<?php echo get_csrf_token(); ?>';
 document.querySelectorAll(".qty-btn").forEach(btn => {
   btn.addEventListener("click", () => {
     const action = btn.dataset.action;
@@ -108,7 +110,7 @@ document.querySelectorAll(".qty-btn").forEach(btn => {
     fetch("update_cart_ajax.php", {
       method: "POST",
       headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-      body: `key=${encodeURIComponent(key)}&quantity=${qty}`
+      body: `key=${encodeURIComponent(key)}&quantity=${qty}&token=${encodeURIComponent(csrfToken)}`
     })
     .then(res => res.json())
     .then(data => {

--- a/checkout.php
+++ b/checkout.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 include 'db.php';
+include 'csrf.php';
 
 $cart = $_SESSION['cart'] ?? [];
 if (empty($cart)) {
@@ -61,6 +62,7 @@ if (empty($cart)) {
 
     <div class="card p-4 shadow mx-auto" style="max-width: 600px;">
         <form method="POST" action="process_checkout.php">
+            <input type="hidden" name="token" value="<?php echo get_csrf_token(); ?>">
             <div class="mb-3">
                 <label class="form-label">Full Name:</label>
                 <input type="text" name="fullname" class="form-control" required>

--- a/csrf.php
+++ b/csrf.php
@@ -1,0 +1,12 @@
+<?php
+function get_csrf_token() {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function verify_csrf_token($token) {
+    return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
+}
+?>

--- a/edit.php
+++ b/edit.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 include 'db.php';
+include 'csrf.php';
 
 // Admin Protection
 if (!isset($_SESSION['admin'])) {
@@ -22,6 +23,9 @@ $success = "";
 $error = "";
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    if (!verify_csrf_token($_POST['token'] ?? '')) {
+        die('Invalid CSRF token');
+    }
     $name = $_POST['name'];
     $price = $_POST['price'];
     $description = $_POST['description'];
@@ -91,6 +95,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
     <div class="card p-4 shadow mx-auto" style="max-width: 600px;">
         <form action="edit.php?id=<?php echo $id; ?>" method="POST" enctype="multipart/form-data">
+            <input type="hidden" name="token" value="<?php echo get_csrf_token(); ?>">
             <div class="mb-3">
                 <label class="form-label">Product Name:</label>
                 <input type="text" name="name" class="form-control" value="<?php echo $product['name']; ?>" required>

--- a/index.php
+++ b/index.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 include 'db.php';
+include 'csrf.php';
 
 $filter = "";
 if (isset($_GET['category'])) {
@@ -64,6 +65,7 @@ $result = mysqli_query($conn, $query);
         echo "<p class='card-text text-muted'>\$ $price</p>";
 
         echo "<form action='add_to_cart.php' method='POST'>";
+        echo "<input type='hidden' name='token' value='" . get_csrf_token() . "'>";
         echo "<input type='hidden' name='product_id' value='$id'>";
         echo "<input type='hidden' name='size' id='selected-size-$id' required>";
         echo "<input type='hidden' name='quantity' value='1'>";

--- a/login.php
+++ b/login.php
@@ -1,10 +1,14 @@
 <?php
 session_start();
 include 'db.php';
+include 'csrf.php';
 
 $error = "";
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    if (!verify_csrf_token($_POST['token'] ?? '')) {
+        die('Invalid CSRF token');
+    }
     $username = $_POST['username'];
     $password = $_POST['password'];
 
@@ -35,6 +39,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         <?php endif; ?>
 
         <form method="POST">
+            <input type="hidden" name="token" value="<?php echo get_csrf_token(); ?>">
             <input type="text" name="username" class="form-control mb-3" placeholder="Username" required>
             <input type="password" name="password" class="form-control mb-3" placeholder="Password" required>
             <button type="submit" class="btn btn-dark w-100">Login</button>

--- a/process_checkout.php
+++ b/process_checkout.php
@@ -1,8 +1,12 @@
 <?php
 session_start();
 include 'db.php';
+include 'csrf.php';
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    if (!verify_csrf_token($_POST['token'] ?? '')) {
+        die('Invalid CSRF token');
+    }
     $username = mysqli_real_escape_string($conn, $_POST['fullname']);
     $phone = mysqli_real_escape_string($conn, $_POST['phone']);
     $address = mysqli_real_escape_string($conn, $_POST['address']);

--- a/products.php
+++ b/products.php
@@ -1,6 +1,7 @@
 <?php
 include 'db.php';
 session_start();
+include 'csrf.php';
 ?>
 
 <!DOCTYPE html>
@@ -56,6 +57,7 @@ session_start();
         }
 
         echo "<form action='add_to_cart.php' method='POST'>";
+        echo "<input type='hidden' name='token' value='" . get_csrf_token() . "'>";
         echo "<input type='hidden' name='product_id' value='{$row['id']}'>";
         echo "<input type='hidden' name='size' id='selected-size-{$id}' required>";
         echo "<input type='hidden' name='quantity' value='1'>";

--- a/register.php
+++ b/register.php
@@ -1,8 +1,13 @@
 <?php
+session_start();
 include 'db.php';
+include 'csrf.php';
 $success = $error = "";
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    if (!verify_csrf_token($_POST['token'] ?? '')) {
+        die('Invalid CSRF token');
+    }
     $username = $_POST['username'];
     $password = $_POST['password'];
     $hashed = password_hash($password, PASSWORD_DEFAULT);
@@ -37,6 +42,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         <?php endif; ?>
 
         <form method="POST">
+            <input type="hidden" name="token" value="<?php echo get_csrf_token(); ?>">
             <input type="text" name="username" class="form-control mb-3" placeholder="Username" required>
             <input type="password" name="password" class="form-control mb-3" placeholder="Password" required>
             <button type="submit" class="btn btn-success w-100">Register</button>

--- a/update_cart_ajax.php
+++ b/update_cart_ajax.php
@@ -1,9 +1,15 @@
 <?php
 session_start();
 include 'db.php';
+include 'csrf.php';
 
-if (!isset($_POST['key'], $_POST['quantity'])) {
+if (!isset($_POST['key'], $_POST['quantity'], $_POST['token'])) {
     echo json_encode(['success' => false, 'message' => 'Invalid request']);
+    exit;
+}
+
+if (!verify_csrf_token($_POST['token'])) {
+    echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
     exit;
 }
 

--- a/visitor_login.php
+++ b/visitor_login.php
@@ -1,8 +1,12 @@
 <?php
 session_start();
 include 'db.php';
+include 'csrf.php';
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    if (!verify_csrf_token($_POST['token'] ?? '')) {
+        die('Invalid CSRF token');
+    }
     $username = $_POST['username'];
     $pass = $_POST['password'];
 
@@ -40,6 +44,7 @@ if (mysqli_num_rows($result) == 1) {
                 <h3 class="text-center mb-4">🔑 Login</h3>
                 <?php if (isset($error)) echo "<div class='alert alert-danger'>$error</div>"; ?>
                 <form method="POST">
+                    <input type="hidden" name="token" value="<?php echo get_csrf_token(); ?>">
                     <div class="mb-3">
                         <label>Username</label>
                         <input type="text" name="username" required class="form-control">


### PR DESCRIPTION
## Summary
- create `csrf.php` helper for token generation and validation
- secure product creation and editing with CSRF checks
- protect login, registration and checkout flows
- validate AJAX cart updates
- embed tokens in all relevant forms and requests

## Testing
- `php -l csrf.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbdfaad14832d817a62cd7b9d6590