### PR TITLE
Fix order creation using POST data

### DIFF
--- a/process_checkout.php
+++ b/process_checkout.php
@@ -3,6 +3,16 @@ session_start();
 include 'db.php';
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    // Read user input
+    $fullname = trim($_POST['fullname'] ?? '');
+    $phone    = trim($_POST['phone'] ?? '');
+    $address  = trim($_POST['address'] ?? '');
+
+    if ($fullname === '' || $phone === '' || $address === '') {
+        $_SESSION['message'] = "❌ Please fill in all the fields.";
+        header("Location: checkout.php");
+        exit();
+    }
 
     $cart = $_SESSION['cart'] ?? [];
 
@@ -35,29 +45,51 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         }
     }
 
-    // ✅ Save order in `orders`
+    // ✅ Use a transaction for order creation and stock updates
+    mysqli_begin_transaction($conn);
+
     $order_stmt = mysqli_prepare($conn, "INSERT INTO orders (username, phone, address, total) VALUES (?, ?, ?, ?)");
-    mysqli_stmt_bind_param($order_stmt, "sssd", $username, $phone, $address, $total);
-    mysqli_stmt_execute($order_stmt);
+    mysqli_stmt_bind_param($order_stmt, "sssd", $fullname, $phone, $address, $total);
+
+    if (!mysqli_stmt_execute($order_stmt)) {
+        mysqli_rollback($conn);
+        $_SESSION['message'] = "❌ Unable to place order.";
+        header("Location: cart.php");
+        exit();
+    }
+
     $order_id = mysqli_insert_id($conn);
 
-    // ✅ Now insert order items and update stock
     foreach ($cart as $item) {
-        $pid = (int)$item['product']['id'];
-        $size = $item['size'];
-        $qty = (int)$item['quantity'];
+        $pid   = (int)$item['product']['id'];
+        $size  = $item['size'];
+        $qty   = (int)$item['quantity'];
         $price = $item['product']['price'];
 
         // Subtract stock
         $update_stmt = mysqli_prepare($conn, "UPDATE product_sizes SET quantity = quantity - ? WHERE product_id = ? AND size = ?");
         mysqli_stmt_bind_param($update_stmt, "iis", $qty, $pid, $size);
-        mysqli_stmt_execute($update_stmt);
+
+        if (!mysqli_stmt_execute($update_stmt)) {
+            mysqli_rollback($conn);
+            $_SESSION['message'] = "❌ Error updating stock.";
+            header("Location: cart.php");
+            exit();
+        }
 
         // Save each item in `order_items`
         $item_stmt = mysqli_prepare($conn, "INSERT INTO order_items (order_id, product_id, size, quantity, price) VALUES (?, ?, ?, ?, ?)");
         mysqli_stmt_bind_param($item_stmt, "iisid", $order_id, $pid, $size, $qty, $price);
-        mysqli_stmt_execute($item_stmt);
+
+        if (!mysqli_stmt_execute($item_stmt)) {
+            mysqli_rollback($conn);
+            $_SESSION['message'] = "❌ Error saving order items.";
+            header("Location: cart.php");
+            exit();
+        }
     }
+
+    mysqli_commit($conn);
 
     unset($_SESSION['cart']);
     $_SESSION['message'] = "✅ Order placed successfully!";


### PR DESCRIPTION
## Summary
- capture `fullname`, `phone` and `address` in `process_checkout.php`
- validate input before processing
- wrap order creation and stock updates in a transaction

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc2daf23c832da116ae628d564052