### PR TITLE
Fix admin orders redirect

### DIFF
--- a/orders.php
+++ b/orders.php
@@ -4,7 +4,7 @@ include 'db.php';
 
 // فقط للمشرفين
 if (!isset($_SESSION['admin'])) {
-    header("Location: admin_login.php");
+    header('Location: login.php');
     exit();
 }
 


### PR DESCRIPTION
## Summary
- ensure orders page redirects to `login.php` for admin sessions

## Testing
- `grep -n Location orders.php`

------
https://chatgpt.com/codex/tasks/task_e_685bc5341110832dbcac25579b50b233