### PR TITLE
Fix admin login prepared statement

### DIFF
--- a/login.php
+++ b/login.php
@@ -8,6 +8,11 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $username = trim($_POST['username']);
     $password = $_POST['password'];
 
+    $stmt = mysqli_prepare($conn, "SELECT password FROM users WHERE username=? AND role='admin'");
+    mysqli_stmt_bind_param($stmt, "s", $username);
+    mysqli_stmt_execute($stmt);
+    $result = mysqli_stmt_get_result($stmt);
+
     if ($result && mysqli_num_rows($result) == 1) {
         $admin = mysqli_fetch_assoc($result);
         if (password_verify($password, $admin['password'])) {


### PR DESCRIPTION
## Summary
- ensure admin login uses prepared statements
- keep existing password verification logic

## Testing
- `php -l login.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc73c54b4832d94dd42588eb24b9f