### PR TITLE
Store logged in user with new orders

### DIFF
--- a/process_checkout.php
+++ b/process_checkout.php
@@ -15,6 +15,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     }
 
     $cart = $_SESSION['cart'] ?? [];
+    $user_id = $_SESSION['visitor']['id'] ?? 0;
 
     if (empty($cart)) {
         $_SESSION['message'] = "❌ Cart is empty.";
@@ -48,8 +49,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     // ✅ Use a transaction for order creation and stock updates
     mysqli_begin_transaction($conn);
 
-    $order_stmt = mysqli_prepare($conn, "INSERT INTO orders (username, phone, address, total) VALUES (?, ?, ?, ?)");
-    mysqli_stmt_bind_param($order_stmt, "sssd", $fullname, $phone, $address, $total);
+    $order_stmt = mysqli_prepare($conn, "INSERT INTO orders (user_id, username, phone, address, total) VALUES (?, ?, ?, ?, ?)");
+    mysqli_stmt_bind_param($order_stmt, "isssd", $user_id, $fullname, $phone, $address, $total);
 
     if (!mysqli_stmt_execute($order_stmt)) {
         mysqli_rollback($conn);


### PR DESCRIPTION
## Summary
- track logged in visitor's id during checkout
- save `user_id` with new orders

## Testing
- `php -l process_checkout.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bd7efce98832d8d8446397b1eb70b