### PR TITLE
Implement CSRF tokens

### DIFF
--- a/add.php
+++ b/add.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once 'session.php';
 include 'db.php';
 
 // حماية الأدمن
@@ -16,10 +16,13 @@ $category_result = mysqli_query($conn, "SELECT * FROM categories");
 $sizes = ['XS', 'S', 'M', 'L', 'XL', 'XXL'];
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    $name = trim($_POST['name']);
-    $price = (float)$_POST['price'];
-    $description = trim($_POST['description']);
-    $category_id = (int)$_POST['category_id'];
+    if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+        $error = "Invalid CSRF token.";
+    } else {
+        $name = trim($_POST['name']);
+        $price = (float)$_POST['price'];
+        $description = trim($_POST['description']);
+        $category_id = (int)$_POST['category_id'];
 
     $allowedExts = ['jpg', 'jpeg', 'png'];
     $allowedTypes = ['image/jpeg', 'image/png'];
@@ -74,6 +77,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
     <div class="card p-4 shadow mx-auto" style="max-width: 600px;">
         <form action="add.php" method="POST" enctype="multipart/form-data">
+            <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
             <div class="mb-3">
                 <label class="form-label">Product Name:</label>
                 <input type="text" name="name" class="form-control" required>

--- a/add_to_cart.php
+++ b/add_to_cart.php
@@ -1,8 +1,13 @@
 <?php
-session_start();
+require_once 'session.php';
 include 'db.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+        $_SESSION['message'] = '❌ Invalid CSRF token.';
+        header('Location: cart.php');
+        exit();
+    }
     $id = (int) $_POST['product_id'];
     $size = trim($_POST['size']);
     $qty = max(1, (int) $_POST['quantity']); // والـ quantity رح توصل كـ hidden = 1

--- a/admin.php
+++ b/admin.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once 'session.php';
 include 'db.php';
 
 // حماية الأدمن

--- a/cart.php
+++ b/cart.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once 'session.php';
 include 'db.php';
 
 $cart = $_SESSION['cart'] ?? [];
@@ -52,7 +52,7 @@ $total = 0;
                   <button class="btn btn-outline-secondary btn-sm qty-btn" data-action="increase">+</button>
                 </div>
                 <p class="mb-1 text-muted subtotal">Subtotal: <strong>$<?= number_format($subtotal, 2) ?></strong></p>
-                <a href="remove_from_cart.php?id=<?= urlencode($key) ?>" class="btn btn-sm btn-outline-danger">🗑️</a>
+                <a href="remove_from_cart.php?id=<?= urlencode($key) ?>&csrf_token=<?= $_SESSION['csrf_token'] ?>" class="btn btn-sm btn-outline-danger">🗑️</a>
               </div>
             </div>
           </div>
@@ -85,6 +85,7 @@ $total = 0;
 
 <!-- ✅ JavaScript -->
 <script>
+const csrfToken = '<?php echo $_SESSION['csrf_token']; ?>';
 document.querySelectorAll(".qty-btn").forEach(btn => {
   btn.addEventListener("click", () => {
     const action = btn.dataset.action;
@@ -108,7 +109,7 @@ document.querySelectorAll(".qty-btn").forEach(btn => {
     fetch("update_cart_ajax.php", {
       method: "POST",
       headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-      body: `key=${encodeURIComponent(key)}&quantity=${qty}`
+      body: `key=${encodeURIComponent(key)}&quantity=${qty}&csrf_token=${encodeURIComponent(csrfToken)}`
     })
     .then(res => res.json())
     .then(data => {

--- a/checkout.php
+++ b/checkout.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once 'session.php';
 include 'db.php';
 
 $cart = $_SESSION['cart'] ?? [];
@@ -61,6 +61,7 @@ if (empty($cart)) {
 
     <div class="card p-4 shadow mx-auto" style="max-width: 600px;">
         <form method="POST" action="process_checkout.php">
+            <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
             <div class="mb-3">
                 <label class="form-label">Full Name:</label>
                 <input type="text" name="fullname" class="form-control" required>

--- a/delete.php
+++ b/delete.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once 'session.php';
 include 'db.php';
 
 // حماية الصفحة

--- a/edit.php
+++ b/edit.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once 'session.php';
 include 'db.php';
 
 // Admin Protection
@@ -24,10 +24,13 @@ $success = "";
 $error = "";
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    $name = trim($_POST['name']);
-    $price = (float)$_POST['price'];
-    $description = trim($_POST['description']);
-    $category_id = (int)$_POST['category_id'];
+    if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+        $error = "Invalid CSRF token.";
+    } else {
+        $name = trim($_POST['name']);
+        $price = (float)$_POST['price'];
+        $description = trim($_POST['description']);
+        $category_id = (int)$_POST['category_id'];
     $stock_xs = (int)($_POST['stock_xs'] ?? 0);
     $stock_s = (int)($_POST['stock_s'] ?? 0);
     $stock_m = (int)($_POST['stock_m'] ?? 0);
@@ -109,6 +112,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
     <div class="card p-4 shadow mx-auto" style="max-width: 600px;">
         <form action="edit.php?id=<?php echo $id; ?>" method="POST" enctype="multipart/form-data">
+            <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
             <div class="mb-3">
                 <label class="form-label">Product Name:</label>
                 <input type="text" name="name" class="form-control" value="<?php echo htmlspecialchars($product['name'], ENT_QUOTES, 'UTF-8'); ?>" required>

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once 'session.php';
 include 'db.php';
 
 $filter = "";
@@ -70,6 +70,7 @@ if (isset($_GET['category'])) {
         echo "<p class='card-text text-muted'>\$ " . htmlspecialchars($price, ENT_QUOTES, 'UTF-8') . "</p>";
 
         echo "<form action='add_to_cart.php' method='POST'>";
+        echo "<input type='hidden' name='csrf_token' value='" . $_SESSION['csrf_token'] . "'>";
         echo "<input type='hidden' name='product_id' value='" . htmlspecialchars($id, ENT_QUOTES, 'UTF-8') . "'>";
         echo "<input type='hidden' name='size' id='selected-size-$id' required>";
         echo "<input type='hidden' name='quantity' value='1'>";

--- a/login.php
+++ b/login.php
@@ -1,29 +1,33 @@
 <?php
-session_start();
+require_once 'session.php';
 include 'db.php';
 
 $error = "";
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    $username = trim($_POST['username']);
-    $password = $_POST['password'];
+    if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+        $error = "Invalid CSRF token.";
+    } else {
+        $username = trim($_POST['username']);
+        $password = $_POST['password'];
 
-    $stmt = mysqli_prepare($conn, "SELECT password FROM users WHERE username=? AND role='admin'");
-    mysqli_stmt_bind_param($stmt, "s", $username);
-    mysqli_stmt_execute($stmt);
-    $result = mysqli_stmt_get_result($stmt);
+        $stmt = mysqli_prepare($conn, "SELECT password FROM users WHERE username=? AND role='admin'");
+        mysqli_stmt_bind_param($stmt, "s", $username);
+        mysqli_stmt_execute($stmt);
+        $result = mysqli_stmt_get_result($stmt);
 
-    if ($result && mysqli_num_rows($result) == 1) {
-        $admin = mysqli_fetch_assoc($result);
-        if (password_verify($password, $admin['password'])) {
-            $_SESSION['admin'] = $username;
-            header("Location: admin.php");
-            exit();
+        if ($result && mysqli_num_rows($result) == 1) {
+            $admin = mysqli_fetch_assoc($result);
+            if (password_verify($password, $admin['password'])) {
+                $_SESSION['admin'] = $username;
+                header("Location: admin.php");
+                exit();
+            } else {
+                $error = "Invalid credentials.";
+            }
         } else {
             $error = "Invalid credentials.";
         }
-    } else {
-        $error = "Invalid credentials.";
     }
 }
 ?>
@@ -42,6 +46,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         <?php endif; ?>
 
         <form method="POST">
+            <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
             <input type="text" name="username" class="form-control mb-3" placeholder="Username" required>
             <input type="password" name="password" class="form-control mb-3" placeholder="Password" required>
             <button type="submit" class="btn btn-dark w-100">Login</button>

--- a/logout.php
+++ b/logout.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once 'session.php';
 session_unset();
 session_destroy();
 header("Location: index.php");

--- a/my_account.php
+++ b/my_account.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once 'session.php';
 
 if (!isset($_SESSION['visitor'])) {
     header("Location: visitor_login.php");

--- a/navbar.php
+++ b/navbar.php
@@ -1,8 +1,6 @@
 
 <?php
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
+require_once 'session.php';
 $visitorLoggedIn = isset($_SESSION['visitor']);
 ?>
 

--- a/orders.php
+++ b/orders.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once 'session.php';
 include 'db.php';
 
 // فقط للمشرفين

--- a/process_checkout.php
+++ b/process_checkout.php
@@ -1,8 +1,13 @@
 <?php
-session_start();
+require_once 'session.php';
 include 'db.php';
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+        $_SESSION['message'] = '❌ Invalid CSRF token.';
+        header('Location: checkout.php');
+        exit();
+    }
     // Read user input
     $fullname = trim($_POST['fullname'] ?? '');
     $phone    = trim($_POST['phone'] ?? '');

--- a/product.php
+++ b/product.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once 'session.php';
 include 'db.php';
 
 if (!isset($_GET['id'])) {
@@ -47,6 +47,7 @@ while ($row = mysqli_fetch_assoc($stock_res)) {
       <p class="h4 text-success mb-4">$<?php echo htmlspecialchars($product['price'], ENT_QUOTES, 'UTF-8'); ?></p>
 
       <form action="add_to_cart.php" method="POST">
+        <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
         <input type="hidden" name="product_id" value="<?php echo $id; ?>">
         <input type="hidden" name="size" id="selected-size-<?php echo $id; ?>" required>
         <input type="hidden" name="quantity" value="1">

--- a/products.php
+++ b/products.php
@@ -1,6 +1,6 @@
 <?php
 include 'db.php';
-session_start();
+require_once 'session.php';
 ?>
 
 <!DOCTYPE html>
@@ -67,6 +67,7 @@ session_start();
         }
 
         echo "<form action='add_to_cart.php' method='POST'>";
+        echo "<input type='hidden' name='csrf_token' value='" . $_SESSION['csrf_token'] . "'>";
         echo "<input type='hidden' name='product_id' value='" . htmlspecialchars($row['id'], ENT_QUOTES, 'UTF-8') . "'>";
         echo "<input type='hidden' name='size' id='selected-size-{$id}' required>";
         echo "<input type='hidden' name='quantity' value='1'>";

--- a/register.php
+++ b/register.php
@@ -1,10 +1,14 @@
 <?php
+require_once 'session.php';
 include 'db.php';
 $success = $error = "";
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    $username = trim($_POST['username']);
-    $password = $_POST['password'];
+    if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+        $error = "Invalid CSRF token.";
+    } else {
+        $username = trim($_POST['username']);
+        $password = $_POST['password'];
 
     if ($username === '' || $password === '') {
         $error = "Please fill in all fields.";
@@ -58,6 +62,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         <?php endif; ?>
 
         <form method="POST">
+            <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
             <input type="text" name="username" class="form-control mb-3" placeholder="Username" required>
             <input type="password" name="password" class="form-control mb-3" placeholder="Password" required>
             <button type="submit" class="btn btn-success w-100">Register</button>

--- a/remove_from_cart.php
+++ b/remove_from_cart.php
@@ -1,8 +1,10 @@
 <?php
-session_start();
+require_once 'session.php';
 
-if (isset($_GET['id']) && isset($_SESSION['cart'][$_GET['id']])) {
+if (isset($_GET['id']) && isset($_GET['csrf_token']) && $_GET['csrf_token'] === $_SESSION['csrf_token'] && isset($_SESSION['cart'][$_GET['id']])) {
     unset($_SESSION['cart'][$_GET['id']]);
+} elseif (isset($_GET['id'])) {
+    $_SESSION['message'] = '❌ Invalid CSRF token.';
 }
 
 header("Location: cart.php");

--- a/session.php
+++ b/session.php
@@ -1,0 +1,8 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+?>

--- a/thank_you.php
+++ b/thank_you.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once 'session.php';
 ?>
 
 <!DOCTYPE html>

--- a/update_cart_ajax.php
+++ b/update_cart_ajax.php
@@ -1,9 +1,14 @@
 <?php
-session_start();
+require_once 'session.php';
 include 'db.php';
 
-if (!isset($_POST['key'], $_POST['quantity'])) {
+if (!isset($_POST['key'], $_POST['quantity'], $_POST['csrf_token'])) {
     echo json_encode(['success' => false, 'message' => 'Invalid request']);
+    exit;
+}
+$csrf = $_POST['csrf_token'];
+if ($csrf !== $_SESSION['csrf_token']) {
+    echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
     exit;
 }
 


### PR DESCRIPTION
## Summary
- create a `session.php` helper that generates CSRF tokens
- include token fields in forms and AJAX calls
- validate tokens in form handlers and show error messages
- replace `session_start()` with `require_once 'session.php'`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bd80414d4832dad5807ba99c052c7