### PR TITLE
Fix stock queries to use prepared statements

### DIFF
--- a/cart.php
+++ b/cart.php
@@ -29,8 +29,11 @@ $total = 0;
 
               // Get max stock for the selected product and size
               $pid = $product['id'];
-              $stock_query = mysqli_query($conn, "SELECT quantity FROM product_sizes WHERE product_id = $pid AND size = '$size'");
-              $stock_row = mysqli_fetch_assoc($stock_query);
+              $stock_stmt = mysqli_prepare($conn, "SELECT quantity FROM product_sizes WHERE product_id = ? AND size = ?");
+              mysqli_stmt_bind_param($stock_stmt, "is", $pid, $size);
+              mysqli_stmt_execute($stock_stmt);
+              $stock_result = mysqli_stmt_get_result($stock_stmt);
+              $stock_row = mysqli_fetch_assoc($stock_result);
               $maxStock = $stock_row['quantity'] ?? 0;
           ?>
           <div class="card mb-3 shadow-sm cart-item" data-key="<?= htmlspecialchars($key, ENT_QUOTES, 'UTF-8') ?>" data-stock="<?= htmlspecialchars($maxStock, ENT_QUOTES, 'UTF-8') ?>">

--- a/update_cart_ajax.php
+++ b/update_cart_ajax.php
@@ -26,10 +26,13 @@ if (!isset($_SESSION['cart'][$key])) {
 
 $item = $_SESSION['cart'][$key];
 $pid = (int) $item['product']['id'];
-$size = mysqli_real_escape_string($conn, $item['size']);
+$size = $item['size'];
 
-// جلب الكمية المتاحة من قاعدة البيانات
-$stock_result = mysqli_query($conn, "SELECT quantity FROM product_sizes WHERE product_id = $pid AND size = '$size'");
+// جلب الكمية المتاحة من قاعدة البيانات باستخدام استعلام محضر
+$stock_stmt = mysqli_prepare($conn, "SELECT quantity FROM product_sizes WHERE product_id = ? AND size = ?");
+mysqli_stmt_bind_param($stock_stmt, "is", $pid, $size);
+mysqli_stmt_execute($stock_stmt);
+$stock_result = mysqli_stmt_get_result($stock_stmt);
 $stock_row = mysqli_fetch_assoc($stock_result);
 $stock = $stock_row['quantity'] ?? 0;
 


### PR DESCRIPTION
## Summary
- use prepared statements for stock checks in cart and AJAX updater

## Testing
- `php -l update_cart_ajax.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685be8602f0c832db6b6936495b1f067