### PR TITLE
Add phone validation and address sanitization

### DIFF
--- a/checkout.php
+++ b/checkout.php
@@ -16,6 +16,11 @@ if (empty($cart)) {
 <body class="bg-light">
 
 <div class="container py-5">
+    <?php if (isset($_SESSION['message'])): ?>
+        <div class="alert alert-warning text-center">
+            <?php echo htmlspecialchars($_SESSION['message'], ENT_QUOTES, 'UTF-8'); unset($_SESSION['message']); ?>
+        </div>
+    <?php endif; ?>
     <h2 class="text-center mb-4">🧾 Review Your Order</h2>
 
     <div class="table-responsive mb-4">
@@ -68,11 +73,11 @@ if (empty($cart)) {
             </div>
             <div class="mb-3">
                 <label class="form-label">Phone:</label>
-                <input type="text" name="phone" class="form-control" required>
+                <input type="text" name="phone" class="form-control" pattern="\+?[0-9\s\-]{7,20}" title="Phone number" required>
             </div>
             <div class="mb-3">
                 <label class="form-label">Address:</label>
-                <textarea name="address" class="form-control" rows="3" required></textarea>
+                <textarea name="address" class="form-control" rows="3" pattern="[\p{L}\d\s,.-]{5,200}" title="Address" required></textarea>
             </div>
             <div class="text-center">
                 <button type="submit" class="btn btn-success w-100">✅ Confirm Order</button>

--- a/process_checkout.php
+++ b/process_checkout.php
@@ -19,6 +19,23 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         exit();
     }
 
+    // ✅ Validate phone number
+    if (!preg_match('/^\+?[0-9\s\-]{7,20}$/', $phone)) {
+        $_SESSION['message'] = "❌ Invalid phone number format.";
+        header("Location: checkout.php");
+        exit();
+    }
+
+    // ✅ Validate address (allow letters, numbers and basic punctuation)
+    if (!preg_match('/^[\p{L}\d\s,.-]{5,200}$/u', $address)) {
+        $_SESSION['message'] = "❌ Invalid address.";
+        header("Location: checkout.php");
+        exit();
+    }
+
+    // ✅ Sanitize address for storage
+    $address = htmlspecialchars($address, ENT_QUOTES, 'UTF-8');
+
     $cart = $_SESSION['cart'] ?? [];
     $user_id = $_SESSION['visitor']['id'] ?? 0;
 


### PR DESCRIPTION
## Summary
- validate phone numbers with regex
- sanitize address input and validate allowed characters
- show flash messages on checkout page
- add HTML validation patterns for phone and address

## Testing
- `php -l process_checkout.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685be86d50e8832dafbe8ee75721ee00