### PR TITLE
Add visitor order listing

### DIFF
--- a/my_account.php
+++ b/my_account.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'session.php';
+include 'db.php';
 
 if (!isset($_SESSION['visitor'])) {
     header("Location: visitor_login.php");
@@ -13,6 +14,13 @@ $cart_count = 0;
 foreach ($cart as $item) {
     $cart_count += $item['quantity'];
 }
+
+// Fetch recent orders for this visitor
+$user_id = $_SESSION['visitor']['id'];
+$order_stmt = mysqli_prepare($conn, "SELECT id, total, order_date FROM orders WHERE user_id=? ORDER BY order_date DESC");
+mysqli_stmt_bind_param($order_stmt, 'i', $user_id);
+mysqli_stmt_execute($order_stmt);
+$orders_result = mysqli_stmt_get_result($order_stmt);
 ?>
 
 
@@ -38,6 +46,34 @@ foreach ($cart as $item) {
             <a href="logout.php" class="btn btn-outline-danger">🚪 Logout</a>
         </div>
     </div>
+</div>
+
+<div class="container py-5">
+    <h4 class="mb-3">🧾 Recent Orders</h4>
+    <?php if (mysqli_num_rows($orders_result) > 0): ?>
+        <table class="table table-bordered text-center">
+            <thead class="table-light">
+                <tr>
+                    <th>#</th>
+                    <th>Total</th>
+                    <th>Date</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php while ($order = mysqli_fetch_assoc($orders_result)): ?>
+                    <tr>
+                        <td><?= $order['id'] ?></td>
+                        <td>$<?= number_format($order['total'], 2) ?></td>
+                        <td><?= $order['order_date'] ?></td>
+                        <td><a href="order_details.php?id=<?= $order['id'] ?>" class="btn btn-sm btn-outline-primary">View</a></td>
+                    </tr>
+                <?php endwhile; ?>
+            </tbody>
+        </table>
+    <?php else: ?>
+        <div class="alert alert-info">No orders found.</div>
+    <?php endif; ?>
 </div>
 
 </body>

--- a/order_details.php
+++ b/order_details.php
@@ -1,0 +1,67 @@
+<?php
+require_once 'session.php';
+include 'db.php';
+
+if (!isset($_SESSION['visitor'])) {
+    header('Location: visitor_login.php');
+    exit();
+}
+
+if (!isset($_GET['id'])) {
+    header('Location: my_account.php');
+    exit();
+}
+
+$order_id = (int)$_GET['id'];
+$user_id = $_SESSION['visitor']['id'];
+
+$stmt = mysqli_prepare($conn, "SELECT * FROM orders WHERE id=? AND user_id=?");
+mysqli_stmt_bind_param($stmt, 'ii', $order_id, $user_id);
+mysqli_stmt_execute($stmt);
+$order_res = mysqli_stmt_get_result($stmt);
+$order = mysqli_fetch_assoc($order_res);
+
+if (!$order) {
+    header('Location: my_account.php');
+    exit();
+}
+
+$item_stmt = mysqli_prepare($conn, "SELECT oi.*, p.name FROM order_items oi JOIN products p ON oi.product_id = p.id WHERE oi.order_id=?");
+mysqli_stmt_bind_param($item_stmt, 'i', $order_id);
+mysqli_stmt_execute($item_stmt);
+$items_res = mysqli_stmt_get_result($item_stmt);
+?>
+<!DOCTYPE html>
+<html>
+<?php include 'head.php'; ?>
+<body class="bg-light">
+<div class="container py-5">
+    <h3 class="mb-4">Order #<?= $order['id'] ?></h3>
+    <p><strong>Date:</strong> <?= $order['order_date'] ?></p>
+    <p><strong>Total:</strong> $<?= number_format($order['total'], 2) ?></p>
+
+    <table class="table table-bordered text-center">
+        <thead class="table-light">
+            <tr>
+                <th>Product</th>
+                <th>Size</th>
+                <th>Qty</th>
+                <th>Price</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php while ($item = mysqli_fetch_assoc($items_res)): ?>
+                <tr>
+                    <td><?= htmlspecialchars($item['name']) ?></td>
+                    <td><?= htmlspecialchars($item['size']) ?></td>
+                    <td><?= $item['quantity'] ?></td>
+                    <td>$<?= number_format($item['price'], 2) ?></td>
+                </tr>
+            <?php endwhile; ?>
+        </tbody>
+    </table>
+
+    <a href="my_account.php" class="btn btn-secondary">&larr; Back to Account</a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- list recent orders on visitor account page
- allow viewing order item details

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be8730b64832db0ea1988504beeec