### PR TITLE
Add PHPUnit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,13 @@ It supports both frontend and admin functionalities, along with size-based inven
    Then open `http://localhost:8000/index.php` in your browser.
 
 The main stylesheet is located at `assets/css/style.css` if you wish to tweak the look and feel.
+
+## 🧪 Running Tests
+
+This project uses PHPUnit for unit tests.
+Install Composer dependencies and run the suite with:
+
+```bash
+composer install
+./vendor/bin/phpunit
+```

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9"
+    },
+    "autoload": {
+        "psr-4": {
+            "Store\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Store\\Tests\\": "tests/"
+        }
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Clothing Store Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -1,0 +1,40 @@
+<?php
+namespace Store;
+
+use PDO;
+
+class Checkout
+{
+    /**
+     * @param array $cart Each item: ['id' => int, 'size' => string, 'qty' => int, 'price' => float]
+     * @return int Order ID
+     */
+    public static function placeOrder(PDO $pdo, int $userId, string $fullname, string $phone, string $address, array $cart): int
+    {
+        if (empty($cart)) {
+            throw new \InvalidArgumentException('Cart is empty');
+        }
+
+        $total = 0;
+        foreach ($cart as $item) {
+            $total += $item['price'] * $item['qty'];
+            $stock = Database::getStock($pdo, $item['id'], $item['size']);
+            if ($stock < $item['qty']) {
+                throw new \RuntimeException('Not enough stock for product ' . $item['id']);
+            }
+        }
+
+        $pdo->beginTransaction();
+        $stmt = $pdo->prepare("INSERT INTO orders (user_id, username, phone, address, total) VALUES (?, ?, ?, ?, ?)");
+        $stmt->execute([$userId, $fullname, $phone, $address, $total]);
+        $orderId = (int)$pdo->lastInsertId();
+
+        foreach ($cart as $item) {
+            Database::decreaseStock($pdo, $item['id'], $item['size'], $item['qty']);
+            $stmt = $pdo->prepare("INSERT INTO order_items (order_id, product_id, size, quantity, price) VALUES (?, ?, ?, ?, ?)");
+            $stmt->execute([$orderId, $item['id'], $item['size'], $item['qty'], $item['price']]);
+        }
+        $pdo->commit();
+        return $orderId;
+    }
+}

--- a/src/Database.php
+++ b/src/Database.php
@@ -1,0 +1,68 @@
+<?php
+namespace Store;
+
+use PDO;
+
+class Database
+{
+    public static function init(PDO $pdo): void
+    {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS products (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            price REAL
+        );");
+
+        $pdo->exec("CREATE TABLE IF NOT EXISTS product_sizes (
+            product_id INTEGER,
+            size TEXT,
+            quantity INTEGER,
+            PRIMARY KEY (product_id, size)
+        );");
+
+        $pdo->exec("CREATE TABLE IF NOT EXISTS orders (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER,
+            username TEXT,
+            phone TEXT,
+            address TEXT,
+            total REAL
+        );");
+
+        $pdo->exec("CREATE TABLE IF NOT EXISTS order_items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            order_id INTEGER,
+            product_id INTEGER,
+            size TEXT,
+            quantity INTEGER,
+            price REAL
+        );");
+    }
+
+    public static function addProduct(PDO $pdo, string $name, float $price): int
+    {
+        $stmt = $pdo->prepare("INSERT INTO products (name, price) VALUES (?, ?)");
+        $stmt->execute([$name, $price]);
+        return (int)$pdo->lastInsertId();
+    }
+
+    public static function setStock(PDO $pdo, int $productId, string $size, int $qty): void
+    {
+        $stmt = $pdo->prepare("INSERT OR REPLACE INTO product_sizes (product_id, size, quantity) VALUES (?, ?, ?)");
+        $stmt->execute([$productId, $size, $qty]);
+    }
+
+    public static function getStock(PDO $pdo, int $productId, string $size): int
+    {
+        $stmt = $pdo->prepare("SELECT quantity FROM product_sizes WHERE product_id = ? AND size = ?");
+        $stmt->execute([$productId, $size]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ? (int)$row['quantity'] : 0;
+    }
+
+    public static function decreaseStock(PDO $pdo, int $productId, string $size, int $qty): void
+    {
+        $stmt = $pdo->prepare("UPDATE product_sizes SET quantity = quantity - ? WHERE product_id = ? AND size = ?");
+        $stmt->execute([$qty, $productId, $size]);
+    }
+}

--- a/tests/CheckoutTest.php
+++ b/tests/CheckoutTest.php
@@ -1,0 +1,42 @@
+<?php
+namespace Store\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Store\Database;
+use Store\Checkout;
+use PDO;
+
+class CheckoutTest extends TestCase
+{
+    private PDO $pdo;
+    private int $pid;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        Database::init($this->pdo);
+        $this->pid = Database::addProduct($this->pdo, 'Jeans', 30.0);
+        Database::setStock($this->pdo, $this->pid, 'L', 5);
+    }
+
+    public function testPlaceOrder(): void
+    {
+        $cart = [
+            ['id' => $this->pid, 'size' => 'L', 'qty' => 2, 'price' => 30.0]
+        ];
+        $orderId = Checkout::placeOrder($this->pdo, 1, 'John Doe', '123', 'Street 1', $cart);
+        $this->assertIsInt($orderId);
+        $this->assertSame(3, Database::getStock($this->pdo, $this->pid, 'L'));
+        $stmt = $this->pdo->query("SELECT COUNT(*) FROM order_items WHERE order_id = $orderId");
+        $this->assertSame(1, (int)$stmt->fetchColumn());
+    }
+
+    public function testPlaceOrderInsufficientStock(): void
+    {
+        $cart = [
+            ['id' => $this->pid, 'size' => 'L', 'qty' => 6, 'price' => 30.0]
+        ];
+        $this->expectException(\RuntimeException::class);
+        Checkout::placeOrder($this->pdo, 1, 'John Doe', '123', 'Street 1', $cart);
+    }
+}

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Store\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Store\Database;
+use PDO;
+
+class DatabaseTest extends TestCase
+{
+    private PDO $pdo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        Database::init($this->pdo);
+    }
+
+    public function testStockFunctions(): void
+    {
+        $pid = Database::addProduct($this->pdo, 'Shirt', 19.99);
+        Database::setStock($this->pdo, $pid, 'M', 10);
+        $this->assertSame(10, Database::getStock($this->pdo, $pid, 'M'));
+        Database::decreaseStock($this->pdo, $pid, 'M', 3);
+        $this->assertSame(7, Database::getStock($this->pdo, $pid, 'M'));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce PHPUnit with composer
- implement `Database` and `Checkout` helper classes
- write unit tests for stock handling and order placement
- document how to run the tests

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685be879e300832d96be92e2bacf06f3