### PR TITLE
Add ADMIN_EMAIL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ DB_HOST=localhost
 DB_USER=root
 DB_PASS=
 DB_NAME=clothing_store
+ADMIN_EMAIL=admin@example.com

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ It supports both frontend and admin functionalities, along with size-based inven
 
 3. Configure PHP:
    - `db.php` reads MySQL credentials from environment variables. Copy `.env.example` to `.env` and adjust the values of `DB_HOST`, `DB_USER`, `DB_PASS`, and `DB_NAME` as needed (defaults are `localhost`, `root`, an empty password, and `clothing_store`).
+   - Set `ADMIN_EMAIL` to the address that should receive order notifications (defaults to `admin@example.com`).
    - Ensure the `mysqli` extension is enabled in `php.ini`.
    - Verify `file_uploads` is `On` and adjust `upload_max_filesize` if needed for product images.
 

--- a/db.php
+++ b/db.php
@@ -3,6 +3,7 @@ $servername = getenv('DB_HOST') ?: 'localhost';
 $username = getenv('DB_USER') ?: 'root';
 $password = getenv('DB_PASS') ?: ''; // خليه فاضي إذا ما حطيت باسورد للـ MySQL
 $dbname = getenv('DB_NAME') ?: 'clothing_store';
+$admin_email = getenv('ADMIN_EMAIL') ?: 'admin@example.com';
 
 // إنشاء الاتصال
 $conn = mysqli_connect($servername, $username, $password, $dbname);

--- a/process_checkout.php
+++ b/process_checkout.php
@@ -114,7 +114,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     mysqli_commit($conn);
 
      $message = "New order #$order_id placed by $fullname. Total: $$total";
-    @mail('abdallahyaish1@gmail.com', 'New Order', $message);
+    $adminEmail = getenv('ADMIN_EMAIL') ?: 'admin@example.com';
+    @mail($adminEmail, 'New Order', $message);
 
     unset($_SESSION['cart']);
     $_SESSION['message'] = "✅ Order placed successfully!";

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -35,7 +35,8 @@ class Checkout
             $stmt->execute([$orderId, $item['id'], $item['size'], $item['qty'], $item['price']]);
         }
         $pdo->commit();
-        @mail('abdallahyaish1@gmail.com', 'New Order', "New order #$orderId placed by $fullname. Total: $$total");
+        $adminEmail = getenv('ADMIN_EMAIL') ?: 'admin@example.com';
+        @mail($adminEmail, 'New Order', "New order #$orderId placed by $fullname. Total: $$total");
         return $orderId;
     }
 }


### PR DESCRIPTION
## Summary
- allow setting ADMIN_EMAIL in `.env.example`
- load ADMIN_EMAIL in `db.php`
- send order notification emails to this configurable address
- document the new variable in README

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c06b7b4a4832dbf024eed870624d2