### PR TITLE
Add strict types to Store classes

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Store;
 
 use PDO;

--- a/src/Database.php
+++ b/src/Database.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Store;
 
 use PDO;


### PR DESCRIPTION
## Summary
- enable strict types in Checkout and Database classes

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c06c806f8832d9f634653f12ecb7f