### PR TITLE
Enable mysqli exception mode

### DIFF
--- a/db.php
+++ b/db.php
@@ -4,13 +4,11 @@ $username = getenv('DB_USER') ?: 'root';
 $password = getenv('DB_PASS') ?: ''; // خليه فاضي إذا ما حطيت باسورد للـ MySQL
 $dbname = getenv('DB_NAME') ?: 'clothing_store';
 
+// Enable exceptions so connection issues throw automatically
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
 // إنشاء الاتصال
 $conn = mysqli_connect($servername, $username, $password, $dbname);
-
-// فحص الاتصال
-if (!$conn) {
-    die("Connection failed: " . mysqli_connect_error());
-}
 // Automatically add the `status` column if the database hasn't been migrated
 $check = mysqli_query($conn, "SHOW COLUMNS FROM orders LIKE 'status'");
 if ($check && mysqli_num_rows($check) === 0) {

--- a/delete.php
+++ b/delete.php
@@ -13,13 +13,14 @@ if (isset($_GET['id'])) {
     $id = (int)$_GET['id'];
 
     // حذف المنتج باستخدام prepared statements
-    $stmt = mysqli_prepare($conn, "DELETE FROM products WHERE id = ?");
-    mysqli_stmt_bind_param($stmt, "i", $id);
-    if (mysqli_stmt_execute($stmt)) {
+    try {
+        $stmt = mysqli_prepare($conn, "DELETE FROM products WHERE id = ?");
+        mysqli_stmt_bind_param($stmt, "i", $id);
+        mysqli_stmt_execute($stmt);
         header("Location: admin.php");
         exit();
-    } else {
-        echo "Error deleting product: " . mysqli_error($conn);
+    } catch (mysqli_sql_exception $e) {
+        echo "Error deleting product: " . $e->getMessage();
     }
 } else {
     echo "No product ID provided.";

--- a/migrate_admin_password.php
+++ b/migrate_admin_password.php
@@ -16,8 +16,9 @@ $plain = $argv[1];
 $hash  = password_hash($plain, PASSWORD_DEFAULT);
 
 $sql = "UPDATE users SET password='" . mysqli_real_escape_string($conn, $hash) . "' WHERE username='admin'";
-if (mysqli_query($conn, $sql)) {
+try {
+    mysqli_query($conn, $sql);
     echo "Admin password updated.\n";
-} else {
-    echo "Error: " . mysqli_error($conn) . "\n";
+} catch (mysqli_sql_exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
 }


### PR DESCRIPTION
## Summary
- throw mysqli exceptions on errors by calling `mysqli_report`
- adapt delete.php and migrate_admin_password.php to catch mysqli exceptions

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c06d17a40832d984b5a50d65bd474