### PR TITLE
Add login and cart update tests

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1,0 +1,31 @@
+<?php
+namespace Store;
+
+use PDO;
+
+class Auth
+{
+    public static function adminLogin(PDO $pdo, string $username, string $password): bool
+    {
+        $stmt = $pdo->prepare("SELECT password FROM users WHERE username = ? AND role = 'admin'");
+        $stmt->execute([$username]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row && password_verify($password, $row['password'])) {
+            $_SESSION['admin'] = $username;
+            return true;
+        }
+        return false;
+    }
+
+    public static function visitorLogin(PDO $pdo, string $username, string $password): bool
+    {
+        $stmt = $pdo->prepare("SELECT id, username, password FROM users WHERE username = ? AND role = 'visitor'");
+        $stmt->execute([$username]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row && password_verify($password, $row['password'])) {
+            $_SESSION['visitor'] = ['id' => $row['id'], 'name' => $row['username']];
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -1,0 +1,38 @@
+<?php
+namespace Store;
+
+use PDO;
+
+class Cart
+{
+    public static function updateQuantity(PDO $pdo, string $key, int $quantity, string $csrfToken): array
+    {
+        if (!isset($_SESSION['csrf_token']) || $csrfToken !== $_SESSION['csrf_token']) {
+            return ['success' => false, 'message' => 'Invalid CSRF token'];
+        }
+        if ($quantity < 1 || $quantity > 1000) {
+            return ['success' => false, 'message' => 'Invalid quantity'];
+        }
+        if (!isset($_SESSION['cart'][$key])) {
+            return ['success' => false, 'message' => 'Item not found in cart'];
+        }
+        $item = $_SESSION['cart'][$key];
+        $pid = (int)$item['product']['id'];
+        $size = $item['size'];
+        $stock = Database::getStock($pdo, $pid, $size);
+        if ($quantity > $stock) {
+            return ['success' => false, 'message' => "❌ Only $stock items in stock for size $size"];
+        }
+        $_SESSION['cart'][$key]['quantity'] = $quantity;
+        $subtotal = $item['product']['price'] * $quantity;
+        $total = 0;
+        foreach ($_SESSION['cart'] as $c) {
+            $total += $c['product']['price'] * $c['quantity'];
+        }
+        return [
+            'success' => true,
+            'subtotal' => number_format($subtotal, 2),
+            'total' => number_format($total, 2)
+        ];
+    }
+}

--- a/tests/CartUpdateTest.php
+++ b/tests/CartUpdateTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace Store\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Store\Database;
+use Store\Cart;
+use PDO;
+
+class CartUpdateTest extends TestCase
+{
+    private PDO $pdo;
+    private int $pid;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        Database::init($this->pdo);
+        $this->pid = Database::addProduct($this->pdo, 'Shirt', 20.0);
+        Database::setStock($this->pdo, $this->pid, 'M', 5);
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION = [];
+        $_SESSION['csrf_token'] = 'token';
+        $_SESSION['cart'] = [
+            'item1' => [
+                'product' => ['id' => $this->pid, 'price' => 20.0],
+                'size' => 'M',
+                'quantity' => 1
+            ]
+        ];
+    }
+
+    public function testUpdateQuantitySuccess(): void
+    {
+        $result = Cart::updateQuantity($this->pdo, 'item1', 3, 'token');
+        $this->assertTrue($result['success']);
+        $this->assertSame(3, $_SESSION['cart']['item1']['quantity']);
+        $this->assertSame('60.00', $result['subtotal']);
+        $this->assertSame('60.00', $result['total']);
+    }
+
+    public function testUpdateQuantityInsufficientStock(): void
+    {
+        $result = Cart::updateQuantity($this->pdo, 'item1', 10, 'token');
+        $this->assertFalse($result['success']);
+        $this->assertSame(1, $_SESSION['cart']['item1']['quantity']);
+    }
+}

--- a/tests/LoginTest.php
+++ b/tests/LoginTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace Store\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Store\Auth;
+use PDO;
+
+class LoginTest extends TestCase
+{
+    private PDO $pdo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->exec("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT, password TEXT, role TEXT)");
+        $stmt = $this->pdo->prepare("INSERT INTO users (username, password, role) VALUES (?, ?, ?), (?, ?, ?)");
+        $stmt->execute([
+            'admin', password_hash('adminpass', PASSWORD_DEFAULT), 'admin',
+            'visitor', password_hash('visitorpass', PASSWORD_DEFAULT), 'visitor'
+        ]);
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION = [];
+    }
+
+    public function testAdminLoginSuccess(): void
+    {
+        $this->assertTrue(Auth::adminLogin($this->pdo, 'admin', 'adminpass'));
+        $this->assertSame('admin', $_SESSION['admin']);
+    }
+
+    public function testAdminLoginFailure(): void
+    {
+        $this->assertFalse(Auth::adminLogin($this->pdo, 'admin', 'wrong'));
+        $this->assertArrayNotHasKey('admin', $_SESSION);
+    }
+
+    public function testVisitorLoginSuccess(): void
+    {
+        $this->assertTrue(Auth::visitorLogin($this->pdo, 'visitor', 'visitorpass'));
+        $this->assertSame('visitor', $_SESSION['visitor']['name']);
+    }
+
+    public function testVisitorLoginFailure(): void
+    {
+        $this->assertFalse(Auth::visitorLogin($this->pdo, 'visitor', 'bad'));
+        $this->assertArrayNotHasKey('visitor', $_SESSION);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `Auth` class for admin and visitor logins
- add `Cart` helper mirroring `update_cart_ajax.php`
- create PHPUnit tests for login success/failure and cart quantity updates

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c06e178b4832d9d3423615a72d8c0