### PR TITLE
Add Gmail credentials check before emails

### DIFF
--- a/process_checkout.php
+++ b/process_checkout.php
@@ -113,9 +113,15 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
     mysqli_commit($conn);
 
-     $message = "New order #$order_id placed by $fullname. Total: $$total";
+    $message = "New order #$order_id placed by $fullname. Total: $$total";
     $adminEmail = getenv('ADMIN_EMAIL') ?: 'admin@example.com';
-    @mail($adminEmail, 'New Order', $message);
+    $gmailUser = getenv('gmail_user');
+    $gmailPass = getenv('gmail_pass');
+    if (!empty($gmailUser) && !empty($gmailPass)) {
+        @mail($adminEmail, 'New Order', $message);
+    } else {
+        error_log('Skipping mail: missing Gmail credentials');
+    }
 
     unset($_SESSION['cart']);
     $_SESSION['message'] = "✅ Order placed successfully!";

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -37,7 +37,13 @@ class Checkout
         }
         $pdo->commit();
         $adminEmail = getenv('ADMIN_EMAIL') ?: 'admin@example.com';
-        @mail($adminEmail, 'New Order', "New order #$orderId placed by $fullname. Total: $$total");
+        $gmailUser = getenv('gmail_user');
+        $gmailPass = getenv('gmail_pass');
+        if (!empty($gmailUser) && !empty($gmailPass)) {
+            @mail($adminEmail, 'New Order', "New order #$orderId placed by $fullname. Total: $$total");
+        } else {
+            error_log('Skipping mail: missing Gmail credentials');
+        }
         return $orderId;
     }
 }


### PR DESCRIPTION
## Summary
- ensure Gmail credentials exist before calling `mail()`

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c0d522dc4832dabc021ff76bdbeec