### PR TITLE
Switch checkout notifications to PHPMailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It supports both frontend and admin functionalities, along with size-based inven
 - Login system for admins
 - Add / Edit / Delete products
 - Manage stock for each size separately
-- View orders with status management and receive email notifications for new orders
+- View orders with status management and receive email notifications for new orders via PHPMailer
 
 ---
 
@@ -48,6 +48,7 @@ It supports both frontend and admin functionalities, along with size-based inven
 3. Configure PHP:
    - `db.php` reads MySQL credentials from environment variables. Copy `.env.example` to `.env` and adjust the values of `DB_HOST`, `DB_USER`, `DB_PASS`, and `DB_NAME` as needed (defaults are `localhost`, `root`, an empty password, and `clothing_store`).
    - Set `ADMIN_EMAIL` to the address that should receive order notifications (defaults to `admin@example.com`).
+     Checkout emails are now sent using [PHPMailer](https://github.com/PHPMailer/PHPMailer).
    - Ensure the `mysqli` extension is enabled in `php.ini`.
    - Verify `file_uploads` is `On` and adjust `upload_max_filesize` if needed for product images.
 

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+    "require": {
+        "phpmailer/phpmailer": "^6.9"
+    },
     "require-dev": {
         "phpunit/phpunit": "^9"
     },

--- a/process_checkout.php
+++ b/process_checkout.php
@@ -1,6 +1,8 @@
 <?php
 require_once 'session.php';
 include 'db.php';
+require_once __DIR__ . '/vendor/autoload.php';
+use PHPMailer\PHPMailer\PHPMailer;
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
@@ -115,7 +117,12 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
      $message = "New order #$order_id placed by $fullname. Total: $$total";
     $adminEmail = getenv('ADMIN_EMAIL') ?: 'admin@example.com';
-    @mail($adminEmail, 'New Order', $message);
+    $mailer = new PHPMailer();
+    $mailer->setFrom('no-reply@localhost');
+    $mailer->addAddress($adminEmail);
+    $mailer->Subject = 'New Order';
+    $mailer->Body = $message;
+    @$mailer->send();
 
     unset($_SESSION['cart']);
     $_SESSION['message'] = "✅ Order placed successfully!";

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace Store;
 
 use PDO;
+use PHPMailer\PHPMailer\PHPMailer;
 
 class Checkout
 {
@@ -37,7 +38,12 @@ class Checkout
         }
         $pdo->commit();
         $adminEmail = getenv('ADMIN_EMAIL') ?: 'admin@example.com';
-        @mail($adminEmail, 'New Order', "New order #$orderId placed by $fullname. Total: $$total");
+        $mailer = new PHPMailer();
+        $mailer->setFrom('no-reply@localhost');
+        $mailer->addAddress($adminEmail);
+        $mailer->Subject = 'New Order';
+        $mailer->Body = "New order #$orderId placed by $fullname. Total: $$total";
+        @$mailer->send();
         return $orderId;
     }
 }


### PR DESCRIPTION
## Summary
- replace `mail()` usage with PHPMailer
- include PHPMailer in composer.json
- document ADMIN_EMAIL and PHPMailer usage in README

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0d52d658832d95c3217633649fdb