### PR TITLE
Use env vars for notification emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ DB_USER=root
 DB_PASS=
 DB_NAME=clothing_store
 ADMIN_EMAIL=admin@example.com
+GMAIL_USER=yourgmail@gmail.com

--- a/db.php
+++ b/db.php
@@ -4,6 +4,7 @@ $username = getenv('DB_USER') ?: 'root';
 $password = getenv('DB_PASS') ?: ''; // خليه فاضي إذا ما حطيت باسورد للـ MySQL
 $dbname = getenv('DB_NAME') ?: 'clothing_store';
 $admin_email = getenv('ADMIN_EMAIL') ?: 'admin@example.com';
+$gmail_user  = getenv('GMAIL_USER') ?: 'yourgmail@gmail.com';
 
 // Enable exceptions so connection issues throw automatically
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);

--- a/process_checkout.php
+++ b/process_checkout.php
@@ -114,8 +114,10 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     mysqli_commit($conn);
 
      $message = "New order #$order_id placed by $fullname. Total: $$total";
-    $adminEmail = getenv('ADMIN_EMAIL') ?: 'admin@example.com';
-    @mail($adminEmail, 'New Order', $message);
+    $adminEmail = $admin_email ?? (getenv('ADMIN_EMAIL') ?: 'admin@example.com');
+    $gmailUser  = $gmail_user ?? (getenv('GMAIL_USER') ?: 'yourgmail@gmail.com');
+    $headers    = "From: $gmailUser";
+    @mail($adminEmail, 'New Order', $message, $headers);
 
     unset($_SESSION['cart']);
     $_SESSION['message'] = "✅ Order placed successfully!";

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -36,8 +36,10 @@ class Checkout
             $stmt->execute([$orderId, $item['id'], $item['size'], $item['qty'], $item['price']]);
         }
         $pdo->commit();
-        $adminEmail = getenv('ADMIN_EMAIL') ?: 'admin@example.com';
-        @mail($adminEmail, 'New Order', "New order #$orderId placed by $fullname. Total: $$total");
+        $adminEmail = $admin_email ?? (getenv('ADMIN_EMAIL') ?: 'admin@example.com');
+        $gmailUser  = $gmail_user ?? (getenv('GMAIL_USER') ?: 'yourgmail@gmail.com');
+        $headers    = "From: $gmailUser";
+        @mail($adminEmail, 'New Order', "New order #$orderId placed by $fullname. Total: $$total", $headers);
         return $orderId;
     }
 }


### PR DESCRIPTION
## Summary
- expose `GMAIL_USER` in `.env.example`
- load `$gmail_user` from environment in `db.php`
- send emails from `$gmail_user` to `$admin_email` in checkout logic

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c0d518fb0832d97600065b4e514b4