### PR TITLE
Add CSRF protection to admin actions

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -48,7 +48,11 @@ $result = mysqli_query($conn, $query);
                         <td><span class="badge bg-secondary"><?php echo htmlspecialchars($row['category_name'], ENT_QUOTES, 'UTF-8'); ?></span></td>
                         <td>
                             <a href="edit.php?id=<?php echo $row['id']; ?>" class="btn btn-warning btn-sm">✏️ Edit</a>
-                            <a href="delete.php?id=<?php echo $row['id']; ?>" class="btn btn-danger btn-sm" onclick="return confirm('Are you sure you want to delete this product?')">🗑️ Delete</a>
+                            <form action="delete.php" method="post" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this product?');">
+                                <input type="hidden" name="id" value="<?php echo $row['id']; ?>">
+                                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
+                                <button type="submit" class="btn btn-danger btn-sm">🗑️ Delete</button>
+                            </form>
                         </td>
                     </tr>
                 <?php } ?>

--- a/delete.php
+++ b/delete.php
@@ -8,9 +8,14 @@ if (!isset($_SESSION['admin'])) {
     exit();
 }
 
-// التحقق من وجود ID
-if (isset($_GET['id'])) {
-    $id = (int)$_GET['id'];
+// التحقق من الطلب وطابع CSRF
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['id'], $_POST['csrf_token'])) {
+    if ($_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+        header('HTTP/1.1 400 Bad Request');
+        exit('Invalid CSRF token');
+    }
+
+    $id = (int)$_POST['id'];
 
     // حذف المنتج باستخدام prepared statements
     try {
@@ -23,6 +28,7 @@ if (isset($_GET['id'])) {
         echo "Error deleting product: " . $e->getMessage();
     }
 } else {
-    echo "No product ID provided.";
+    header('HTTP/1.1 405 Method Not Allowed');
+    echo 'Invalid request.';
 }
 ?>

--- a/orders.php
+++ b/orders.php
@@ -45,6 +45,7 @@ $result = mysqli_query($conn, $query);
           <td>
             <form method="post" action="update_order_status.php" class="d-flex justify-content-center">
               <input type="hidden" name="id" value="<?= $row['id'] ?>">
+              <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?>">
               <select name="status" class="form-select form-select-sm w-auto">
                 <?php $current = isset($row['status']) ? $row['status'] : 'pending'; ?>
                 <?php foreach(['pending','preparing','completed'] as $st): ?>

--- a/update_order_status.php
+++ b/update_order_status.php
@@ -9,8 +9,9 @@ if (!isset($_SESSION['admin'])) {
 
 $id = (int)($_POST['id'] ?? 0);
 $status = $_POST['status'] ?? '';
+$token = $_POST['csrf_token'] ?? '';
 $allowed = ['pending','preparing','completed'];
-if ($id && in_array($status, $allowed, true)) {
+if ($id && in_array($status, $allowed, true) && $token === $_SESSION['csrf_token']) {
     $stmt = mysqli_prepare($conn, "UPDATE orders SET status=? WHERE id=?");
     mysqli_stmt_bind_param($stmt, 'si', $status, $id);
     mysqli_stmt_execute($stmt);


### PR DESCRIPTION
## Summary
- use a CSRF protected POST form for product deletion
- validate token in delete.php and only accept POST
- include CSRF token in order status forms
- verify token when updating order status

## Testing
- `composer install` *(fails: composer not installed)*
- `phpunit` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c174fc77c832da8c0fe4bed894225