### PR TITLE
Add CSRF failure test for cart quantity update

### DIFF
--- a/tests/CartUpdateTest.php
+++ b/tests/CartUpdateTest.php
@@ -46,4 +46,11 @@ class CartUpdateTest extends TestCase
         $this->assertFalse($result['success']);
         $this->assertSame(1, $_SESSION['cart']['item1']['quantity']);
     }
+
+    public function testUpdateQuantityInvalidCsrf(): void
+    {
+        $result = Cart::updateQuantity($this->pdo, 'item1', 2, 'wrong');
+        $this->assertFalse($result['success']);
+        $this->assertSame(1, $_SESSION['cart']['item1']['quantity']);
+    }
 }


### PR DESCRIPTION
## Summary
- add unit test ensuring Cart::updateQuantity fails with invalid CSRF token

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml tests/CartUpdateTest.php` *(fails: No such file or directory)*
- `phpunit --configuration phpunit.xml tests/CartUpdateTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c17538f08832d9b126e2b9bcd98d8