### PR TITLE
Fix coupon discount handling

### DIFF
--- a/checkout.php
+++ b/checkout.php
@@ -79,6 +79,10 @@ if (empty($cart)) {
                 <label class="form-label">Address:</label>
                 <textarea name="address" class="form-control" rows="3" pattern="[\p{L}\d\s,.-]{5,200}" title="Address" required></textarea>
             </div>
+            <div class="mb-3">
+                <label class="form-label">Coupon Code (optional):</label>
+                <input type="text" name="coupon" class="form-control">
+            </div>
             <div class="text-center">
                 <button type="submit" class="btn btn-success w-100">✅ Confirm Order</button>
             </div>

--- a/process_checkout.php
+++ b/process_checkout.php
@@ -38,6 +38,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
     $cart = $_SESSION['cart'] ?? [];
     $user_id = $_SESSION['visitor']['id'] ?? 0;
+    $coupon = strtoupper(trim($_POST['coupon'] ?? ''));
+    $discountPercent = $coupon === 'SAVE10' ? 10 : 0;
 
     if (empty($cart)) {
         $_SESSION['message'] = "❌ Cart is empty.";
@@ -48,6 +50,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $total = 0;
     foreach ($cart as $item) {
         $total += $item['product']['price'] * $item['quantity'];
+    }
+    if ($discountPercent > 0) {
+        $total -= $total * ($discountPercent / 100);
     }
 
     // ✅ Check stock first

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -8,9 +8,10 @@ class Checkout
 {
     /**
      * @param array $cart Each item: ['id' => int, 'size' => string, 'qty' => int, 'price' => float]
+     * @param float $discountPercent Percent off to apply to total
      * @return int Order ID
      */
-    public static function placeOrder(PDO $pdo, int $userId, string $fullname, string $phone, string $address, array $cart): int
+    public static function placeOrder(PDO $pdo, int $userId, string $fullname, string $phone, string $address, array $cart, float $discountPercent = 0.0): int
     {
         if (empty($cart)) {
             throw new \InvalidArgumentException('Cart is empty');
@@ -23,6 +24,11 @@ class Checkout
             if ($stock < $item['qty']) {
                 throw new \RuntimeException('Not enough stock for product ' . $item['id']);
             }
+        }
+
+        if ($discountPercent > 0) {
+            $discountPercent = max(0.0, min(100.0, $discountPercent));
+            $total -= $total * ($discountPercent / 100);
         }
 
         $pdo->beginTransaction();

--- a/tests/CheckoutTest.php
+++ b/tests/CheckoutTest.php
@@ -41,4 +41,14 @@ class CheckoutTest extends TestCase
         $this->expectException(\RuntimeException::class);
         Checkout::placeOrder($this->pdo, 1, 'John Doe', '123', 'Street 1', $cart);
     }
+
+    public function testPlaceOrderWithDiscount(): void
+    {
+        $cart = [
+            ['id' => $this->pid, 'size' => 'L', 'qty' => 2, 'price' => 30.0]
+        ];
+        $orderId = Checkout::placeOrder($this->pdo, 1, 'Jane', '555', 'Street 2', $cart, 10.0);
+        $total = $this->pdo->query("SELECT total FROM orders WHERE id = $orderId")->fetchColumn();
+        $this->assertSame(54.0, (float)$total);
+    }
 }


### PR DESCRIPTION
## Summary
- add coupon field to checkout form
- support coupon processing in checkout handler
- allow a discount percent in Checkout::placeOrder
- test placing an order with a discount

## Testing
- `./vendor/bin/phpunit --stop-on-failure` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c375fe044832d84e35170d799c1d5